### PR TITLE
change url format

### DIFF
--- a/content/blog/hello-world/index.md
+++ b/content/blog/hello-world/index.md
@@ -1,6 +1,6 @@
 ---
 title: Hello World
-date: "2015-05-01T22:12:03.284Z"
+date: "2015-05-01T22:12:03+09:00"
 description: "Hello World"
 tags: ["雑記", "Gatsby.js"]
 ---

--- a/content/blog/my-second-post/index.md
+++ b/content/blog/my-second-post/index.md
@@ -1,6 +1,6 @@
 ---
 title: My Second Post!
-date: "2015-05-06T23:46:37.121Z"
+date: "2015-05-06T23:46:37+09:00"
 ---
 
 Wow! I love blogging so much already.

--- a/content/blog/new-beginnings/index.md
+++ b/content/blog/new-beginnings/index.md
@@ -1,6 +1,6 @@
 ---
 title: New Beginnings
-date: "2015-05-28T22:40:32.169Z"
+date: "2015-05-28T22:40:32+09:00"
 description: This is a custom description for SEO and Open Graph purposes, rather than the default generated excerpt. Simply add a description field to the frontmatter.
 ---
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -33,6 +33,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
         }
         frontmatter {
           tags
+          date
         }
       }
     }
@@ -62,9 +63,10 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
     posts.forEach((post, index) => {
       const previousPostId = index === 0 ? null : posts[index - 1].id
       const nextPostId = index === posts.length - 1 ? null : posts[index + 1].id
+      const moment = require('moment');
 
       createPage({
-        path: post.fields.slug,
+        path: moment(post.frontmatter.date).format('YYYYMMDDHHmmss'),
         component: blogPost,
         context: {
           id: post.id,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,6 +5,7 @@ import Bio from "../components/bio"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 import kebabCase from "lodash/kebabCase"
+const moment = require('moment');
 
 const BlogIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`
@@ -32,7 +33,7 @@ const BlogIndex = ({ data, location }) => {
           const tags = post.frontmatter.tags
           
           return (
-            <li key={post.fields.slug}>
+            <li key={post.frontmatter.date}>
               <article
                 className="post-list-item"
                 itemScope
@@ -40,11 +41,11 @@ const BlogIndex = ({ data, location }) => {
               >
                 <header>
                   <h2>
-                    <Link to={post.fields.slug} itemProp="url">
+                    <Link to={moment(post.frontmatter.date).format(`YYYYMMDDHHmmss`)} itemProp="url">
                       <span itemProp="headline">{title}</span>
                     </Link>
                   </h2>
-                  <small>{post.frontmatter.date}</small>
+                  <small>{moment(post.frontmatter.date).format(`YYYY-MM-DDTHH:mm:ss`)}</small>
 
                   <div className="tags-article">
                     {tags && tags.length > 0 && tags.map(tag => {
@@ -97,7 +98,7 @@ export const pageQuery = graphql`
           slug
         }
         frontmatter {
-          date(formatString: "MMMM DD, YYYY")
+          date
           title
           description
           tags

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -5,6 +5,7 @@ import Bio from "../components/bio"
 import Layout from "../components/layout"
 import Seo from "../components/seo"
 import kebabCase from "lodash/kebabCase"
+const moment = require('moment');
 
 const BlogPostTemplate = ({
   data: { previous, next, site, markdownRemark: post },
@@ -21,7 +22,7 @@ const BlogPostTemplate = ({
       >
         <header>
           <h1 itemProp="headline">{post.frontmatter.title}</h1>
-          <p>{post.frontmatter.date}</p>
+          <p>{moment(post.frontmatter.date).format(`YYYY-MM-DDTHH:mm:ss`)}</p>
 
           <div className="tags-article">
             {tags && tags.length > 0 && tags.map(tag => {
@@ -55,14 +56,14 @@ const BlogPostTemplate = ({
         >
           <li>
             {previous && (
-              <Link to={previous.fields.slug} rel="prev">
+              <Link to={`/${moment(previous.frontmatter.date).format('YYYYMMDDHHmmss')}`} rel="prev">
                 ← {previous.frontmatter.title}
               </Link>
             )}
           </li>
           <li>
             {next && (
-              <Link to={next.fields.slug} rel="next">
+              <Link to={`/${moment(next.frontmatter.date).format('YYYYMMDDHHmmss')}`} rel="next">
                 {next.frontmatter.title} →
               </Link>
             )}
@@ -101,7 +102,7 @@ export const pageQuery = graphql`
       html
       frontmatter {
         title
-        date(formatString: "MMMM DD, YYYY")
+        date
         description
         tags
       }
@@ -112,6 +113,7 @@ export const pageQuery = graphql`
       }
       frontmatter {
         title
+        date
       }
     }
     next: markdownRemark(id: { eq: $nextPostId }) {
@@ -120,6 +122,7 @@ export const pageQuery = graphql`
       }
       frontmatter {
         title
+        date
       }
     }
   }

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -40,7 +40,7 @@ const Tags = ({ data, pageContext, location }) => {
               >
                 <header>
                   <h2>
-                    <Link to={post.fields.slug} itemProp="url">
+                    <Link to={`/${moment(post.frontmatter.date).format(`YYYYMMDDHHmmss`)}`} itemProp="url">
                       <span itemProp="headline">{title}</span>
                     </Link>
                   </h2>


### PR DESCRIPTION
URLのフォーマットを変更します。

CJKV語圏の利用者であれば、URIがマルチバイト文字を使用することは不思議なことではありません。
現代のインターネットにおいて日本語ドメインが利用可能であり、ページにマルチバイト文字を使うことには反対しません。

ですが、WWW（ワールドワイドウェブ）を提唱したティム・バーナーズ・リーが1998年に提唱した「Cool URIs don't change（クールなURIは変更されない）」に従うべきと考えます。

* [Cool URIs don't change](https://www.w3.org/Provider/Style/URI.html)
* [クールなURIは変わらない](https://www.kanzaki.com/docs/Style/URI.html)

変更前（gatsby-standard-blogデフォルトの設定）
* `content/blog/hello-world/index.md` => `http://sample/hello-world/`
* `content/blog/猫が好き/index.md` => `http://sample/猫が好き/`

変更後
* content/blog/hello-world/index.md  => http://sample/20221221221222/

`date`は`2022-12-21T22:12:22+09:00`と時差を記述します。

日付の記述方法は色々ありますが、ISO 8601に定義されているフォーマットが恒久的に使用できると思います。

```yaml
---
title: Hello World
date: "2022-12-21T22:12:22+09:00"
description: "Hello World"
---
```
日付のフォーマットはgatsbyjsに内蔵されているmoment.jsを使用します。

graphql の frontmatter は以下で統一します。
```
date
```
markdownのフロントマターの日付を取得して、ページ生成する部分でフォーマットを整えます。
自由に変えられるので、ページ生成するときにUTCに戻したり、日本人になじみ深い`2022年12月22日22時12分`にすることもできます。