### PR TITLE
fix warning

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,9 +48,9 @@ const BlogIndex = ({ data, location }) => {
                   <small>{moment(post.frontmatter.date).format(`YYYY-MM-DDTHH:mm:ss`)}</small>
 
                   <div className="tags-article">
-                    {tags && tags.length > 0 && tags.map(tag => {
+                    {tags && tags.length > 0 && tags.map((tag, index) => {
                       return (
-                        <Link to={`/tags/${kebabCase(tag)}/`} itemProp="url">
+                        <Link to={`/tags/${kebabCase(tag)}/`} itemProp="url" key={index}>
                           <button>{tag}</button>
                         </Link>
                       )

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -25,9 +25,9 @@ const BlogPostTemplate = ({
           <p>{moment(post.frontmatter.date).format(`YYYY-MM-DDTHH:mm:ss`)}</p>
 
           <div className="tags-article">
-            {tags && tags.length > 0 && tags.map(tag => {
+            {tags && tags.length > 0 && tags.map((tag, index) => {
               return (
-                <Link to={`/tags/${kebabCase(tag)}/`} itemProp="url">
+                <Link to={`/tags/${kebabCase(tag)}/`} itemProp="url" key={index}>
                   <button>{tag}</button>
                 </Link>
               )

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -52,9 +52,9 @@ const Tags = ({ data, pageContext, location }) => {
                   <div className="tags-index">
                     {tags &&
                       tags.length > 0 &&
-                      tags.map(tag => {
+                      tags.map((tag, index) => {
                         return (
-                          <Link to={`/tags/${kebabCase(tag)}/`} itemProp="url">
+                          <Link to={`/tags/${kebabCase(tag)}/`} itemProp="url" key={index}>
                             <button>{tag}</button>
                           </Link>
                         )


### PR DESCRIPTION
devtool の console に表示されるエラーを修正します。
reactで key が無いとどの項目が変更、追加、削除されたのか識別できないので key を設定します。

* `src/pages/index.js`
* `src/templates/tags.js` <= gatsby-starter-blog にはないファイル。
* `src/templates/blog-post.js`

* https://reactjs.org/docs/lists-and-keys.html#keys

<details><summary>/src/templates/blog-post.jsにアクセスしたとき表示される console</summary>

```react
react.development.js:209 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `BlogPostTemplate`. See https://reactjs.org/link/warning-keys for more information.
    at BlogPostTemplate (webpack-internal:///./src/templates/blog-post.js?export=default:23:11)
    at PageRenderer (webpack-internal:///./.cache/page-renderer.js:24:76)
    at PageQueryStore (webpack-internal:///./.cache/query-result-store.js:35:30)
    at RouteHandler
    at div
    at re (webpack-internal:///./node_modules/@gatsbyjs/reach-router/dist/index.modern.mjs:36:9865)
    at ee (webpack-internal:///./node_modules/@gatsbyjs/reach-router/dist/index.modern.mjs:36:9680)
    at ae (webpack-internal:///./node_modules/@gatsbyjs/reach-router/dist/index.modern.mjs:36:10957)
    at oe (webpack-internal:///./node_modules/@gatsbyjs/reach-router/dist/index.modern.mjs:36:10831)
    at ScrollHandler (webpack-internal:///./node_modules/gatsby-react-router-scroll/scroll-handler.js:36:35)
    at RouteUpdates (webpack-internal:///./.cache/navigation.js:253:32)
    at EnsureResources (webpack-internal:///./.cache/ensure-resources.js:19:30)
    at LocationHandler (webpack-internal:///./.cache/root.js:62:29)
    at eval (webpack-internal:///./node_modules/@gatsbyjs/reach-router/dist/index.modern.mjs:36:8283)
    at F (webpack-internal:///./node_modules/@gatsbyjs/reach-router/dist/index.modern.mjs:36:7181)
    at H (webpack-internal:///./node_modules/@gatsbyjs/reach-router/dist/index.modern.mjs:36:7483)
    at WithErrorBoundary()
    at G (webpack-internal:///./node_modules/@gatsbyjs/reach-router/dist/index.modern.mjs:36:9074)
    at Root
    at StaticQueryStore (webpack-internal:///./.cache/query-result-store.js:130:32)
    at SliceDataStore (webpack-internal:///./.cache/query-result-store.js:177:32)
    at ErrorBoundary (webpack-internal:///./.cache/fast-refresh-overlay/components/error-boundary.js:21:35)
    at DevOverlay (webpack-internal:///./.cache/fast-refresh-overlay/index.js:119:5)
    at RootWrappedWithOverlayAndProvider
    at App (webpack-internal:///./.cache/app.js:167:80)
```

</details>
