### PR TITLE
add draft

### DIFF
--- a/content/blog/hello-world/index.md
+++ b/content/blog/hello-world/index.md
@@ -3,6 +3,7 @@ title: Hello World
 date: "2015-05-01T22:12:03+09:00"
 description: "Hello World"
 tags: ["雑記", "Gatsby.js"]
+draft: true
 ---
 
 This is my first post on my new fake blog! How exciting!

--- a/content/blog/my-second-post/index.md
+++ b/content/blog/my-second-post/index.md
@@ -1,6 +1,7 @@
 ---
 title: My Second Post!
 date: "2015-05-06T23:46:37+09:00"
+tags: ["雑記", "Gatsby.js"]
 ---
 
 Wow! I love blogging so much already.

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -24,7 +24,9 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
   const result = await graphql(`
   {
     postsRemark: allMarkdownRemark(
-      sort: { frontmatter: { date: ASC }}, limit: 2000
+      sort: { frontmatter: { date: ASC }}
+      ${process.env.NODE_ENV === 'production' ? 'filter: { frontmatter: { draft: { ne: true } } }' : '' }
+      limit: 2000
     ) {
       nodes {
         id

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,7 @@ const moment = require('moment');
 
 const BlogIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`
-  const posts = data.allMarkdownRemark.nodes
+  const posts = process.env.NODE_ENV === 'production' ? data.allMarkdownRemark.nodes.filter((value) => !value.frontmatter.draft) : data.allMarkdownRemark.nodes
 
   if (posts.length === 0) {
     return (
@@ -102,6 +102,7 @@ export const pageQuery = graphql`
           title
           description
           tags
+          draft
         }
       }
     }

--- a/src/templates/tags.js
+++ b/src/templates/tags.js
@@ -9,7 +9,7 @@ import Seo from "../components/seo"
 const Tags = ({ data, pageContext, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`
   const { totalCount } = data.allMarkdownRemark
-  const posts = data.allMarkdownRemark.nodes
+  const posts = process.env.NODE_ENV === 'production' ? data.allMarkdownRemark.nodes.filter((value) => !value.frontmatter.draft) : data.allMarkdownRemark.nodes
   const { tag } = pageContext
 
   if (posts.length === 0) {
@@ -103,6 +103,7 @@ export const pageQuery = graphql`
           title
           description
           tags
+          draft
         }
       }
     }


### PR DESCRIPTION
下書き機能を追加します。

md ファイルの yaml に 以下を記述して、`gatsby build`で記事は作成されなくなります。一方、`gatsby develop`では作成されます。

```
draft: true
```
記事の下部についている、前後の記事を移動するリンクも生成されなくなります。

このリポジトリは、タグ機能も実装しています。
タグ一覧も `draft: true` が指定されている記事はリンクが生成されなくなります。

テスト目的で、`gatsby develop` 実行時に下書きを生成したくないときは、以下が記述されたファイルすべてを変更します。

```
before
process.env.NODE_ENV === 'production' ? data.allMarkdownRemark.nodes.filter((value) => !value.frontmatter.draft) : data.allMarkdownRemark.nodes

after
process.env.NODE_ENV === 'development' ? data.allMarkdownRemark.nodes.filter((value) => !value.frontmatter.draft) : data.allMarkdownRemark.nodes
```
